### PR TITLE
Prevented pod install ERROR

### DIFF
--- a/ios/RNFs.podspec
+++ b/ios/RNFs.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNFs
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/author/RNFs.git"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Added an homepage to prevent a `pod install` or  `npx pod-install` ERROR which prevents the installation to go trough.